### PR TITLE
readme: filamentphp.com listing badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Tests](https://img.shields.io/github/actions/workflow/status/packstub/filament-account-switcher/tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/packstub/filament-account-switcher/actions/workflows/tests.yml)
 [![Total Downloads](https://img.shields.io/packagist/dt/packstub/filament-account-switcher.svg?style=flat-square)](https://packagist.org/packages/packstub/filament-account-switcher)
 [![License](https://img.shields.io/packagist/l/packstub/filament-account-switcher.svg?style=flat-square)](https://github.com/packstub/filament-account-switcher/blob/main/LICENSE.md)
+[![Listed on filamentphp.com](https://img.shields.io/badge/filamentphp.com-listed-fb7185?style=flat-square&logo=filament&logoColor=white)](https://filamentphp.com/plugins/packstub-account-switcher)
 
 </div>
 


### PR DESCRIPTION
Packstub Account Switcher is approved on the filamentphp.com plugin directory (2026-08-31).

- README: `Listed on filamentphp.com` shields badge added to the badge row (inside the existing `filament-hidden` block, so it shows on GitHub/Packagist only), linking to https://filamentphp.com/plugins/packstub-account-switcher.
