### PR TITLE
Write the switch log and linked-accounts pivot on the user model's connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `packstub/filament-account-switcher` are documented here.
 
+## 4.0.3 — 2026-09-03
+
+### Fixed
+
+- The switch log and the linked-accounts pivot were written on the default connection. With multi-database tenancy that is the tenant connection, where the tables do not exist (`no such table: account_switches`). Both models — and the migrations — now follow the user model's connection; a new `connection` config key pins it explicitly.
+- The switch confirmation modal for a link that does not require a password no longer asks for one in its description.
+
 ## 4.0.2 — 2026-08-26
 
 ### Fixed

--- a/config/packstub-account-switcher.php
+++ b/config/packstub-account-switcher.php
@@ -17,6 +17,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Database connection
+    |--------------------------------------------------------------------------
+    |
+    | The connection the linked_accounts and account_switches tables live on.
+    | Leave null to use the user model's connection, so multi-database
+    | tenancy setups (e.g. a `CentralConnection` user model) keep both
+    | tables next to the users table instead of on the tenant connection.
+    |
+    */
+
+    'connection' => null,
+
+    /*
+    |--------------------------------------------------------------------------
     | Tables
     |--------------------------------------------------------------------------
     */

--- a/database/migrations/create_account_switches_table.php.stub
+++ b/database/migrations/create_account_switches_table.php.stub
@@ -12,7 +12,7 @@ return new class extends Migration
         $userModel = AccountSwitcher::userModel();
         $usersTable = (new $userModel)->getTable();
 
-        Schema::create(config('packstub-account-switcher.tables.account_switches', 'account_switches'), function (Blueprint $table) use ($userModel, $usersTable): void {
+        Schema::connection(AccountSwitcher::connectionName())->create(config('packstub-account-switcher.tables.account_switches', 'account_switches'), function (Blueprint $table) use ($userModel, $usersTable): void {
             $table->id();
             $table->foreignIdFor($userModel, 'from_user_id')->nullable()->constrained($usersTable)->nullOnDelete();
             $table->foreignIdFor($userModel, 'to_user_id')->constrained($usersTable)->cascadeOnDelete();
@@ -27,6 +27,6 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::dropIfExists(config('packstub-account-switcher.tables.account_switches', 'account_switches'));
+        Schema::connection(AccountSwitcher::connectionName())->dropIfExists(config('packstub-account-switcher.tables.account_switches', 'account_switches'));
     }
 };

--- a/database/migrations/create_linked_accounts_table.php.stub
+++ b/database/migrations/create_linked_accounts_table.php.stub
@@ -11,7 +11,7 @@ return new class extends Migration
     {
         $userModel = AccountSwitcher::userModel();
 
-        Schema::create(config('packstub-account-switcher.tables.linked_accounts', 'linked_accounts'), function (Blueprint $table) use ($userModel): void {
+        Schema::connection(AccountSwitcher::connectionName())->create(config('packstub-account-switcher.tables.linked_accounts', 'linked_accounts'), function (Blueprint $table) use ($userModel): void {
             $table->id();
             $table->foreignIdFor($userModel, 'user_id')->constrained()->cascadeOnDelete();
             $table->foreignIdFor($userModel, 'linked_user_id')->constrained((new $userModel)->getTable())->cascadeOnDelete();
@@ -25,6 +25,6 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::dropIfExists(config('packstub-account-switcher.tables.linked_accounts', 'linked_accounts'));
+        Schema::connection(AccountSwitcher::connectionName())->dropIfExists(config('packstub-account-switcher.tables.linked_accounts', 'linked_accounts'));
     }
 };

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,6 +72,10 @@ return [
     // null = config('auth.providers.users.model').
     'user_model' => null,
 
+    // The connection both tables live on.
+    // null = the user model's connection.
+    'connection' => null,
+
     'tables' => [
         'linked_accounts' => 'linked_accounts',
         'account_switches' => 'account_switches',
@@ -95,6 +99,10 @@ return [
 ### User model
 
 Linked accounts and the switch log are relationships on one user model. It is resolved from `user_model`, falling back to `auth.providers.users.model`. Set it **before** running the migrations — they derive the foreign keys and the referenced table from it.
+
+### Connection
+
+Both tables follow the user model's connection, so they always sit next to the `users` table. That is what a multi-database tenancy setup needs: a user model on a central connection keeps linked accounts and the switch log central, even while a request runs on a tenant connection. Set `connection` to pin them somewhere else. The migrations honour the same setting.
 
 ## The switch log
 

--- a/resources/lang/en/account-switcher.php
+++ b/resources/lang/en/account-switcher.php
@@ -9,6 +9,7 @@ return [
         'password' => 'Password of the account you are switching to',
         'confirm_heading' => 'Switch to :account',
         'confirm_description' => 'Confirm you own this account by entering its password.',
+        'confirm_description_no_password' => 'You will be signed in as :account without leaving this session. You can switch back at any time.',
     ],
 
     'impersonate' => [

--- a/src/AccountSwitcher.php
+++ b/src/AccountSwitcher.php
@@ -38,6 +38,23 @@ class AccountSwitcher
             ?? config('auth.providers.users.model');
     }
 
+    /**
+     * The connection the plugin's tables live on: the configured one, or
+     * the user model's own connection (null = the application default).
+     */
+    public static function connectionName(): ?string
+    {
+        $connection = config('packstub-account-switcher.connection');
+
+        if (filled($connection)) {
+            return $connection;
+        }
+
+        $userModel = static::userModel();
+
+        return $userModel ? (new $userModel)->getConnectionName() : null;
+    }
+
     public function plugin(): ?AccountSwitcherPlugin
     {
         $panel = Filament::getCurrentOrDefaultPanel();

--- a/src/Filament/Livewire/AccountSwitcherMenu.php
+++ b/src/Filament/Livewire/AccountSwitcherMenu.php
@@ -34,14 +34,23 @@ class AccountSwitcherMenu extends Component implements HasActions, HasSchemas
             ->modalHeading(fn (array $arguments): string => __('packstub-account-switcher::account-switcher.menu.confirm_heading', [
                 'account' => $this->accountLabel($this->resolveAccount($arguments)),
             ]))
-            ->modalDescription(fn (): string => __('packstub-account-switcher::account-switcher.menu.confirm_description'))
+            ->modalDescription(function (array $arguments): string {
+                $account = $this->resolveAccount($arguments);
+
+                if ($account && ! $this->requiresPassword($account)) {
+                    return __('packstub-account-switcher::account-switcher.menu.confirm_description_no_password', [
+                        'account' => $this->accountLabel($account),
+                    ]);
+                }
+
+                return __('packstub-account-switcher::account-switcher.menu.confirm_description');
+            })
             ->modalSubmitActionLabel(fn (): string => __('packstub-account-switcher::account-switcher.menu.switch'))
             ->modalWidth('sm')
             ->schema(function (array $arguments): array {
                 $account = $this->resolveAccount($arguments);
-                $user = Filament::auth()->user();
 
-                if (! $account || ! $user || ! app(AccountSwitcher::class)->requiresPassword($user, $account)) {
+                if (! $account || ! $this->requiresPassword($account)) {
                     return [];
                 }
 
@@ -122,6 +131,13 @@ class AccountSwitcherMenu extends Component implements HasActions, HasSchemas
             'manageUrl' => $this->getManageUrl(),
             'plugin' => AccountSwitcherPlugin::get(),
         ]);
+    }
+
+    protected function requiresPassword(Model $account): bool
+    {
+        $user = Filament::auth()->user();
+
+        return ! $user || app(AccountSwitcher::class)->requiresPassword($user, $account);
     }
 
     /**

--- a/src/Models/AccountSwitch.php
+++ b/src/Models/AccountSwitch.php
@@ -27,6 +27,11 @@ class AccountSwitch extends Model
 
     protected $guarded = [];
 
+    public function getConnectionName(): ?string
+    {
+        return $this->connection ?? AccountSwitcher::connectionName();
+    }
+
     public function getTable(): string
     {
         return config('packstub-account-switcher.tables.account_switches', 'account_switches');

--- a/src/Models/LinkedAccount.php
+++ b/src/Models/LinkedAccount.php
@@ -24,6 +24,11 @@ class LinkedAccount extends Pivot
 
     protected $guarded = [];
 
+    public function getConnectionName(): ?string
+    {
+        return $this->connection ?? AccountSwitcher::connectionName();
+    }
+
     public function getTable(): string
     {
         return config('packstub-account-switcher.tables.linked_accounts', 'linked_accounts');

--- a/tests/Feature/AccountSwitcherMenuTest.php
+++ b/tests/Feature/AccountSwitcherMenuTest.php
@@ -49,8 +49,16 @@ it('switches without a password requirement', function (): void {
 
     $this->actingAs($admin);
 
-    Livewire::test(AccountSwitcherMenu::class)
-        ->callAction('switch', arguments: ['account' => $daily->id])
+    $component = Livewire::test(AccountSwitcherMenu::class)
+        ->mountAction('switch', arguments: ['account' => $daily->id])
+        ->assertActionMounted('switch');
+
+    expect((string) $component->instance()->getMountedAction()->getModalDescription())
+        ->toContain('You will be signed in as')
+        ->not->toContain('password');
+
+    $component
+        ->callMountedAction()
         ->assertRedirect('http://localhost/admin');
 
     expect(Filament::auth()->user()->is($daily))->toBeTrue();

--- a/tests/Feature/LinkedAccountSwitchTest.php
+++ b/tests/Feature/LinkedAccountSwitchTest.php
@@ -1,10 +1,13 @@
 <?php
 
 use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Schema;
 use Packstub\AccountSwitcher\Enums\SwitchReason;
 use Packstub\AccountSwitcher\Exceptions\AccountSwitchDenied;
 use Packstub\AccountSwitcher\Facades\AccountSwitcher;
 use Packstub\AccountSwitcher\Models\AccountSwitch;
+use Packstub\AccountSwitcher\Tests\Fixtures\CentralUser;
 
 it('links symmetrically and idempotently', function (): void {
     $admin = createAdmin();
@@ -102,4 +105,44 @@ it('lets the plugin gate deny switching', function (): void {
     expect(AccountSwitcher::canSwitchToLinkedAccount($user, $other))->toBeFalse();
 
     AccountSwitcher::plugin()->canSwitchUsing(null);
+});
+
+it('keeps the switch log on the user model connection', function (): void {
+    // A second connection standing in for a tenant database: it becomes the
+    // default, as a multi-database tenancy package would make it mid-request.
+    config()->set('database.connections.tenant', [
+        'driver' => 'sqlite',
+        'database' => ':memory:',
+        'prefix' => '',
+    ]);
+    config()->set('database.default', 'tenant');
+    config()->set('packstub-account-switcher.user_model', CentralUser::class);
+
+    $admin = CentralUser::query()->create(['name' => 'Admin', 'email' => 'admin@central.test', 'password' => Hash::make('secret'), 'is_admin' => true]);
+    $daily = CentralUser::query()->create(['name' => 'Daily', 'email' => 'daily@central.test', 'password' => Hash::make('secret')]);
+    $admin->linkAccount($daily, requiresPassword: false);
+
+    $this->actingAs($admin);
+
+    expect(AccountSwitcher::connectionName())->toBe('sqlite')
+        ->and((new AccountSwitch)->getConnectionName())->toBe('sqlite');
+
+    AccountSwitcher::switchToLinkedAccount($daily);
+
+    expect(AccountSwitch::query()->count())->toBe(1)
+        ->and(Schema::connection('tenant')->hasTable('account_switches'))->toBeFalse();
+});
+
+it('pins the tables to the configured connection', function (): void {
+    config()->set('database.connections.audit', [
+        'driver' => 'sqlite',
+        'database' => ':memory:',
+        'prefix' => '',
+    ]);
+    config()->set('packstub-account-switcher.connection', 'audit');
+
+    (include __DIR__.'/../../database/migrations/create_account_switches_table.php.stub')->up();
+
+    expect((new AccountSwitch)->getConnectionName())->toBe('audit')
+        ->and(Schema::connection('audit')->hasTable('account_switches'))->toBeTrue();
 });

--- a/tests/Fixtures/CentralUser.php
+++ b/tests/Fixtures/CentralUser.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Packstub\AccountSwitcher\Tests\Fixtures;
+
+/**
+ * A user model pinned to one connection, the way multi-database tenancy
+ * packages pin the central user model while tenant requests run on
+ * another default connection.
+ */
+class CentralUser extends User
+{
+    protected $connection = 'sqlite';
+}


### PR DESCRIPTION
## Why

On a tenant host in a multi-database `stancl/tenancy` app the *default* connection is the tenant database, while the user model is pinned to the central one. Switching accounts logged the user in and then failed inserting the audit row:

```
SQLSTATE[HY000]: General error: 1 no such table: account_switches
```

The session had already switched, so the user landed on the target account with an error page. The `linked_accounts` pivot only worked because it is queried through the user model.

A second, cosmetic problem: a link configured without a password requirement showed a modal that said "enter its password" with no password field, which read as a bug.

## What

- `AccountSwitcher::connectionName()` resolves the connection for the plugin's tables: the new `connection` config key when set, otherwise the user model's own connection.
- `AccountSwitch` and `LinkedAccount` override `getConnectionName()` to use it; the two migration stubs create and drop through `Schema::connection(...)`.
- The confirmation modal for a no-password link now explains that you will be signed in without leaving the session.
- Docs: `docs/configuration.md` gains the `connection` section. Changelog entry for 4.0.3.

## Tests

- New: models land on the user model's connection when the default is a tenant connection; the `connection` config override wins; the no-password modal shows the new description.
- `vendor/bin/pest`: 34 passed. Pint clean.

Verified in the browser on `acme-shop.test` (packstub-demo): switch without password, switch back with password, both audit rows in the central database, no new log entries.

Companion demo PR: packstub/demo (published config + copied migrations).
