### PR TITLE
Pin the release checkout to a SHA

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -22,7 +22,7 @@ jobs:
       TAG: ${{ inputs.tag || github.ref_name }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ inputs.tag || github.ref_name }}
 


### PR DESCRIPTION
The release workflow was the only one still referencing `actions/checkout@v7` by tag. Pin it to the same v7.0.1 SHA the other three workflows use, per the repo's SHA-pinning convention.

Plumb flags this line as the sole security deduction (GitHub Actions pinned to SHA: 8 of 9). Once merged, its next daily sweep should score the package 100.